### PR TITLE
fix(FEC-12045): CDN balancer service called twice

### DIFF
--- a/src/smart-switch.js
+++ b/src/smart-switch.js
@@ -25,7 +25,6 @@ class SmartSwitch extends BasePlugin {
   constructor(name: string, player: KalturaPlayer, config: SmartSwitchConfig) {
     super(name, player, config);
     this._responseTimeoutMs = this.config.responseTimeoutSec * 1000;
-    this._createCdnBalancerPromise();
   }
 
   getEngineDecorator(engine: IEngine): IEngineDecorator {


### PR DESCRIPTION
### Description of the Changes

issue: CDN balancer service called twice
fix: remove the redundant call on the constructor

solves: FEC-12045

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
